### PR TITLE
Add corporate-level pricing optimizer

### DIFF
--- a/price_optimizer.py
+++ b/price_optimizer.py
@@ -1,0 +1,337 @@
+import csv
+import statistics
+import os
+import re
+from pathlib import Path
+from typing import List, Dict
+
+
+PRICE_STEP = 0.25  # granularity for optimizer
+
+
+def clean_prices(prices: List[float]) -> List[float]:
+    """Remove outliers and invalid data from scraped prices."""
+    valid = [p for p in prices if 0 < p < 1000]
+    if len(valid) >= 4:
+        q1, q3 = statistics.quantiles(valid, n=4)[0], statistics.quantiles(valid, n=4)[2]
+        iqr = q3 - q1
+        low = q1 - 1.5 * iqr
+        high = q3 + 1.5 * iqr
+        valid = [p for p in valid if low <= p <= high]
+    return valid
+
+
+def optimize_price(
+    prices: List[float],
+    current_price: float,
+    unit_cost: float,
+    margin: float,
+    elasticity: float = 1.2,
+    max_markup: float = 1.8,
+    price_step: float = PRICE_STEP,
+    demand_base: float = 100.0,
+) -> float:
+    """Search for a price that maximizes estimated profit."""
+    base = unit_cost * (1 + margin)
+    if not prices:
+        return round_price(max(base, current_price))
+
+    avg = statistics.mean(prices)
+    min_p = min(prices)
+    max_p = max(prices)
+
+    low = max(base, min_p * 0.9, current_price * 0.9)
+    high = min(avg * max_markup, max_p * 1.2, current_price * max_markup, base * max_markup)
+    if high < low:
+        high = low * 1.1
+
+    best_p = base
+    best_profit = -1e9
+    price = low
+    while price <= high:
+        profit = simulate_profit(price, unit_cost, avg, demand_base, elasticity)
+        if profit > best_profit:
+            best_profit = profit
+            best_p = price
+        price += price_step
+
+    best_p = max(best_p, base)
+    return round_price(best_p)
+
+try:
+    import requests
+except ImportError:  # requests might not be installed; LLM calls become optional
+    requests = None
+
+
+OVERVIEW_CSV = "Dzukou_Pricing_Overview_With_Names - Copy.csv"
+MAPPING_CSV = "product_data_mapping.csv"
+
+# Minimum profit margins by category
+PROFIT_MARGINS = {
+    "Sunglasses": 0.15,
+    "Bottles": 0.10,
+    "Phone accessories": 0.10,
+    "Notebook": 0.10,
+    "Lunchbox": 0.10,
+    "Premium shawls": 0.30,
+    "Eri silk shawls": 0.20,
+    "Cotton scarf": 0.15,
+    "Other scarves and shawls": 0.15,
+    "Cushion covers": 0.20,
+    "Coasters & placements": 0.15,
+    "Towels": 0.15,
+}
+
+# Category-specific demand elasticity (higher values mean more price sensitive)
+DEMAND_ELASTICITY = {
+    "Sunglasses": 1.3,
+    "Bottles": 1.1,
+    "Phone accessories": 1.2,
+    "Notebook": 1.0,
+    "Lunchbox": 1.0,
+    "Premium shawls": 0.8,
+    "Eri silk shawls": 0.9,
+    "Cotton scarf": 1.1,
+    "Other scarves and shawls": 1.1,
+    "Cushion covers": 1.0,
+    "Coasters & placements": 1.0,
+    "Towels": 1.0,
+}
+
+# Maximum markup relative to the average competitor price
+MAX_MARKUP = {
+    "Sunglasses": 1.8,
+    "Bottles": 1.6,
+    "Phone accessories": 1.5,
+    "Notebook": 1.5,
+    "Lunchbox": 1.6,
+    "Premium shawls": 2.0,
+    "Eri silk shawls": 1.9,
+    "Cotton scarf": 1.7,
+    "Other scarves and shawls": 1.7,
+    "Cushion covers": 1.6,
+    "Coasters & placements": 1.6,
+    "Towels": 1.5,
+}
+
+
+
+def round_price(price: float) -> float:
+    """Round price to a corporate-friendly format (e.g., 0.99)."""
+    return round(price * 2) / 2 - 0.01
+
+CATEGORY_KEYWORDS = {
+    "Sunglasses": ["sunglasses"],
+    "Bottles": ["bottle"],
+    "Phone accessories": ["phone"],
+    "Notebook": ["notebook"],
+    "Lunchbox": ["lunchbox"],
+    "Premium shawls": ["premium shawl"],
+    "Eri silk shawls": ["eri silk"],
+    "Cotton scarf": ["cotton scarf"],
+    "Other scarves and shawls": ["stole", "shawl", "scarf"],
+}
+
+
+def categorize_product(name: str) -> str:
+    name_l = name.lower()
+    for category, keywords in CATEGORY_KEYWORDS.items():
+        for kw in keywords:
+            if kw in name_l:
+                return category
+    return "Other scarves and shawls"  # default to shawls if unknown
+
+
+def read_overview() -> Dict[str, Dict[str, float]]:
+    data = {}
+    # The overview CSV may come from Excel and often uses Windows-1252 encoding
+    with open(OVERVIEW_CSV, newline="", encoding="cp1252") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            name = row["Product Name"].strip()
+            cur_price = float(row[" Current Price "].replace("€", "").strip())
+            unit_cost = float(row[" Unit Cost "].replace("€", "").strip())
+            data[name] = {"current_price": cur_price, "unit_cost": unit_cost}
+    return data
+
+
+def read_prices(csv_path: Path) -> List[float]:
+    prices = []
+    with open(csv_path, newline="", encoding="cp1252") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            price = row.get("price") or row.get("Price")
+            if price:
+                price = price.replace("€", "").replace(",", "").strip()
+                try:
+                    value = float(price)
+                except ValueError:
+                    continue
+                if 0 < value < 1000:
+                    prices.append(value)
+    return clean_prices(prices)
+
+
+def call_mistral(prompt: str) -> float:
+    """Query the Mistral API and extract a numeric price from the response."""
+    if requests is None:
+        raise RuntimeError("requests package not installed")
+    api_key = os.environ.get("MISTRAL_API_KEY")
+    if not api_key:
+        raise RuntimeError("MISTRAL_API_KEY environment variable not set")
+    url = "https://api.mistral.ai/v1/chat/completions"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    data = {
+        "model": "mistral-large-latest",
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    resp = requests.post(url, headers=headers, json=data, timeout=10)
+    resp.raise_for_status()
+    content = resp.json()["choices"][0]["message"]["content"]
+    match = re.search(r"\d+(?:\.\d+)?", content)
+    if not match:
+        raise ValueError("No numeric price returned")
+    return float(match.group())
+
+
+def simulate_profit(price: float, unit_cost: float, avg_competitor: float, demand_base: float = 100.0, elasticity: float = 1.2) -> float:
+    """Simple demand model to estimate profit for backtesting."""
+    if price <= 0:
+        return 0.0
+    demand = demand_base * (avg_competitor / price) ** elasticity
+    return demand * (price - unit_cost)
+
+
+
+
+def suggest_price(
+    product_name: str,
+    category: str,
+    prices: List[float],
+    cur: float,
+    unit: float,
+) -> float:
+    margin = PROFIT_MARGINS.get(category, 0.15)
+    elasticity = DEMAND_ELASTICITY.get(category, 1.2)
+    max_markup = MAX_MARKUP.get(category, 1.8)
+
+    if not prices:
+        return round_price(max(unit * (1 + margin), cur))
+
+    avg = statistics.mean(prices)
+    median = statistics.median(prices)
+    stdev = statistics.stdev(prices) if len(prices) > 1 else 0.0
+    min_p = min(prices)
+    max_p = max(prices)
+    prompt = (
+        f"Product: {product_name}\n"
+        f"Category: {category}\n"
+        f"Competitor prices: {', '.join(f'{p:.2f}' for p in prices)}\n"
+        f"Average price: {avg:.2f}\n"
+        f"Median price: {median:.2f}\n"
+        f"Std Dev: {stdev:.2f}\n"
+        f"Min price: {min_p:.2f}\n"
+        f"Max price: {max_p:.2f}\n"
+        f"Current price: {cur:.2f}\n"
+        f"Unit cost: {unit:.2f}\n"
+        f"Required margin: {margin*100:.0f}%\n"
+        "Recommend a competitive selling price that maximizes profit. "
+        "Only respond with the number."
+    )
+    try:
+        price = call_mistral(prompt)
+    except Exception:
+        price = optimize_price(
+            prices,
+            cur,
+            unit,
+            margin,
+            elasticity=elasticity,
+            max_markup=max_markup,
+        )
+    return round_price(price)
+
+
+def main():
+    overview = read_overview()
+    results = []
+    total_current = 0.0
+    total_recommended = 0.0
+    with open(MAPPING_CSV, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            name = row["Product Name"].strip()
+            data_file = Path(row["Data File"].strip())
+            info = overview.get(name)
+            if not info:
+                continue
+            category = categorize_product(name)
+            prices = read_prices(data_file)
+            price = suggest_price(
+                name,
+                category,
+                prices,
+                info["current_price"],
+                info["unit_cost"],
+            )
+            avg = statistics.mean(prices) if prices else info["current_price"]
+            median = statistics.median(prices) if prices else info["current_price"]
+            stdev = statistics.stdev(prices) if len(prices) > 1 else 0.0
+            min_p = min(prices) if prices else info["current_price"]
+            max_p = max(prices) if prices else info["current_price"]
+
+            profit_cur = simulate_profit(info["current_price"], info["unit_cost"], avg)
+            profit_new = simulate_profit(price, info["unit_cost"], avg)
+
+            total_current += profit_cur
+            total_recommended += profit_new
+
+            results.append({
+                "Product Name": name,
+                "Product ID": row["Product ID"],
+                "Recommended Price": f"{price:.2f}",
+                "Category": category,
+                "Avg Competitor Price": f"{avg:.2f}",
+                "Min Competitor Price": f"{min_p:.2f}",
+                "Max Competitor Price": f"{max_p:.2f}",
+                "Median Competitor Price": f"{median:.2f}",
+                "Std Competitor Price": f"{stdev:.2f}",
+                "Competitor Count": len(prices),
+                "Profit Current": f"{profit_cur:.2f}",
+                "Profit Recommended": f"{profit_new:.2f}",
+                "Profit Delta": f"{(profit_new - profit_cur):.2f}",
+            })
+    out_path = Path("recommended_prices.csv")
+    with open(out_path, "w", newline="") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                "Product Name",
+                "Product ID",
+                "Recommended Price",
+                "Category",
+                "Avg Competitor Price",
+                "Min Competitor Price",
+                "Max Competitor Price",
+                "Median Competitor Price",
+                "Std Competitor Price",
+                "Competitor Count",
+                "Profit Current",
+                "Profit Recommended",
+                "Profit Delta",
+            ],
+        )
+        writer.writeheader()
+        writer.writerows(results)
+    print(f"Saved {len(results)} recommendations to {out_path}")
+    print(
+        f"Total estimated profit now: {total_current:.2f} -> {total_recommended:.2f} (delta {(total_recommended-total_current):.2f})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/product_data_mapping.csv
+++ b/product_data_mapping.csv
@@ -1,0 +1,13 @@
+Product Name,Product ID,Data File
+Reiek Peak Wooden Sunglasses (Incl. cork casing),SG0001,product_data/wooden_sunglasses.csv
+Fibonacci Wooden Sunglasses (Incl. cork casing),SG0002,product_data/wooden_sunglasses.csv
+Elephant Falls Thermos Bottle,BT0005,product_data/thermos_bottles.csv
+Saint Elias Thermos bottles,BT0012-13,product_data/thermos_bottles.csv
+Inca Trail Coffee Mugs,BT0015-16,product_data/coffee_mugs.csv
+Woodland Mouse Phone Stand,PS0007,product_data/phone_stand.csv
+Tiger Trail Notebooks,NB0011-12,product_data/notebooks.csv
+Papillon Notebooks,NB0013-15,product_data/notebooks.csv
+Jim Corbett Lunchbox Band 1200ML,LB0017,product_data/lunch_box_1200ml.csv
+Jim Corbett Lunchbox Band 800ML,LB0019,product_data/lunch_box_800ml.csv
+Timeless Silk Colored Stole,SH0017-26,product_data/silk_colored_stole.csv
+Silk Uncut White Stole,SH0025,product_data/white_silk_stole.csv

--- a/recommended_prices.csv
+++ b/recommended_prices.csv
@@ -1,0 +1,13 @@
+Product Name,Product ID,Recommended Price,Category,Avg Competitor Price,Min Competitor Price,Max Competitor Price,Median Competitor Price,Std Competitor Price,Competitor Count,Profit Current,Profit Recommended,Profit Delta
+Reiek Peak Wooden Sunglasses (Incl. cork casing),SG0001,56.99,Sunglasses,25.26,1.00,79.99,20.99,17.55,220,1614.40,1610.92,-3.48
+Fibonacci Wooden Sunglasses (Incl. cork casing),SG0002,60.99,Sunglasses,25.26,1.00,79.99,20.99,17.55,220,1625.29,1623.90,-1.39
+Elephant Falls Thermos Bottle,BT0005,31.49,Bottles,31.33,1.00,99.00,24.99,22.04,187,2306.19,2300.96,-5.24
+Saint Elias Thermos bottles,BT0012-13,32.49,Bottles,31.33,1.00,99.00,24.99,22.04,187,2225.29,2219.11,-6.18
+Inca Trail Coffee Mugs,BT0015-16,31.49,Other scarves and shawls,29.24,1.00,87.98,24.99,19.82,217,2103.87,2098.72,-5.15
+Woodland Mouse Phone Stand,PS0007,17.99,Phone accessories,27.07,1.00,90.00,21.99,20.31,183,2444.99,2445.65,0.66
+Tiger Trail Notebooks,NB0011-12,25.49,Notebook,19.28,1.00,70.00,14.50,14.49,240,1341.21,1337.41,-3.80
+Papillon Notebooks,NB0013-15,23.49,Notebook,19.28,1.00,70.00,14.50,14.49,240,1444.34,1442.06,-2.28
+Jim Corbett Lunchbox Band 1200ML,LB0017,33.99,Lunchbox,31.27,1.00,89.99,28.00,19.90,115,1267.85,1315.54,47.69
+Jim Corbett Lunchbox Band 800ML,LB0019,30.49,Lunchbox,26.87,1.00,82.00,22.49,17.80,160,1971.70,1967.92,-3.78
+Timeless Silk Colored Stole,SH0017-26,72.99,Other scarves and shawls,26.96,1.00,79.99,23.49,18.51,314,1027.05,1014.22,-12.82
+Silk Uncut White Stole,SH0025,113.49,Other scarves and shawls,31.31,1.00,99.00,24.99,22.52,289,1701.61,1696.78,-4.83

--- a/scraper.py
+++ b/scraper.py
@@ -1,0 +1,419 @@
+import requests
+from bs4 import BeautifulSoup
+import pandas as pd
+import time
+import re
+from urllib.parse import quote
+import random
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.chrome.options import Options
+import logging
+import os
+import sys
+from datetime import datetime
+
+# Configure logging with UTF-8 encoding
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.StreamHandler(sys.stdout),
+        logging.FileHandler('scraper.log', encoding='utf-8')
+    ]
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ProductScraper:
+    def __init__(self):
+        self.session = requests.Session()
+
+        # Rotate user agents
+        self.user_agents = [
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0'
+        ]
+
+        self.session.headers.update({
+            'User-Agent': random.choice(self.user_agents),
+            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+            'Accept-Language': 'en-US,en;q=0.5'
+        })
+
+        # Configure Chrome options for Selenium
+        self.chrome_options = Options()
+        self.chrome_options.add_argument('--headless')
+        self.chrome_options.add_argument('--no-sandbox')
+        self.chrome_options.add_argument('--disable-dev-shm-usage')
+        self.chrome_options.add_argument('--disable-gpu')
+        self.chrome_options.add_argument(f'--user-agent={random.choice(self.user_agents)}')
+
+        # Store configurations for the target stores
+        self.stores = {
+            'Made Trade': {
+                'url': 'https://www.madetrade.com',
+                'search_pattern': '/search?q={}'
+            },
+            'EarthHero': {
+                'url': 'https://earthhero.com',
+                'search_pattern': '/search?q={}'
+            },
+            'Package Free Shop': {
+                'url': 'https://packagefreeshop.com',
+                'search_pattern': '/search?q={}'
+            },
+            'Ten Thousand Villages': {
+                'url': 'https://www.tenthousandvillages.com',
+                'search_pattern': '/search?q={}'
+            },
+            'Zero Waste Store': {
+                'url': 'https://zerowastestoreonline.com',
+                'search_pattern': '/search?q={}'
+            }
+        }
+
+        # Product categories with search terms and output CSV file names
+        self.product_categories = {
+            'Wooden Sunglasses': {
+                'search_terms': [
+                    'wooden sunglasses',
+                    'wood sunglasses',
+                    'sustainable sunglasses',
+                    'bamboo sunglasses',
+                    'eco-friendly sunglasses',
+                    'natural wood eyewear'
+                ],
+                'csv_filename': 'wooden_sunglasses.csv'
+            },
+            'Thermos Bottles': {
+                'search_terms': [
+                    'thermos bottle',
+                    'stainless steel bottle',
+                    'insulated bottle',
+                    'vacuum insulated bottle',
+                    'eco water bottle',
+                    'sustainable water bottle'
+                ],
+                'csv_filename': 'thermos_bottles.csv'
+            },
+            'Coffee Mugs': {
+                'search_terms': [
+                    'coffee mug',
+                    'ceramic mug',
+                    'bamboo mug',
+                    'eco-friendly mug',
+                    'sustainable coffee cup',
+                    'reusable coffee mug'
+                ],
+                'csv_filename': 'coffee_mugs.csv'
+            },
+            'Lunch Box 1200ML': {
+                'search_terms': [
+                    '1200ml lunch box',
+                    'lunch box 1200ml',
+                    'large lunch container',
+                    'stainless steel lunch box large',
+                    'eco lunch box large',
+                    '1.2L food container'
+                ],
+                'csv_filename': 'lunch_box_1200ml.csv'
+            },
+            'Lunch Box 800ML': {
+                'search_terms': [
+                    '800ml lunch box',
+                    'lunch box 800ml',
+                    'medium lunch container',
+                    'stainless steel lunch box medium',
+                    'eco lunch box medium',
+                    '800ml food container'
+                ],
+                'csv_filename': 'lunch_box_800ml.csv'
+            },
+            'Silk Colored Stole': {
+                'search_terms': [
+                    'silk colored stole',
+                    'colored silk stole',
+                    'silk stole',
+                    'colorful silk stole',
+                    'silk scarf colored',
+                    'vibrant silk stole',
+                    'multicolor silk wrap',
+                    'printed silk stole',
+                    'silk wrap colored',
+                    'handmade silk stole',
+                    'artisan silk scarf',
+                    'fair trade silk stole'
+                ],
+                'csv_filename': 'silk_colored_stole.csv'
+            },
+            'White Silk Stole': {
+                'search_terms': [
+                    'white silk stole',
+                    'white stole',
+                    'silk white stole',
+                    'pure white silk stole',
+                    'white silk scarf',
+                    'white silk wrap',
+                    'ivory silk stole',
+                    'cream silk stole',
+                    'white silk shawl',
+                    'natural white silk stole',
+                    'organic white silk',
+                    'handmade white silk'
+                ],
+                'csv_filename': 'white_silk_stole.csv'
+            },
+            'Phone Stand': {
+                'search_terms': [
+                    'phone stand',
+                    'wooden phone stand',
+                    'bamboo phone holder',
+                    'eco-friendly phone stand',
+                    'sustainable phone holder',
+                    'natural wood phone dock',
+                    'desk phone stand',
+                    'mobile phone holder'
+                ],
+                'csv_filename': 'phone_stand.csv'
+            },
+            'Notebooks': {
+                'search_terms': [
+                    'eco notebook',
+                    'sustainable notebook',
+                    'recycled paper journal',
+                    'bamboo notebook',
+                    'eco-friendly journal',
+                    'handmade paper notebook',
+                    'hemp paper notebook',
+                    'tree-free journal'
+                ],
+                'csv_filename': 'notebooks.csv'
+            }
+        }
+
+        # Create a directory for CSV files if it doesn't exist
+        self.csv_dir = 'product_data'
+        os.makedirs(self.csv_dir, exist_ok=True)
+
+        # Storage for results by category
+        self.results_by_category = {category: [] for category in self.product_categories}
+
+    def clean_price(self, price_text: str):
+        """Extract the numeric price from raw text."""
+        if not price_text:
+            return None
+        price_match = re.search(r'(\$|€|£|Rs\.?|USD)?\s*(\d+[\.,]\d+|\d+)', price_text)
+        if price_match:
+            price_str = price_match.group(2).replace(',', '.')
+            try:
+                return float(price_str)
+            except ValueError:
+                return None
+        return None
+
+    def clean_product_name(self, name: str):
+        if not name:
+            return None
+        name = name.strip()
+        if len(name) < 3:
+            return None
+        if not re.search(r'[a-zA-Z]', name):
+            return None
+        return name
+
+    def extract_products_from_html(self, html_content: bytes, search_term: str):
+        products = []
+        soup = BeautifulSoup(html_content, 'html.parser')
+        price_elements = soup.find_all(string=re.compile(r'\$\s*\d+'))
+        for price_element in price_elements:
+            try:
+                parent = price_element.parent
+                for _ in range(3):
+                    if parent and parent.parent:
+                        parent = parent.parent
+                if not parent:
+                    continue
+                name_elements = parent.find_all(['h1', 'h2', 'h3', 'h4', 'a', 'span', 'div'])
+                product_name = None
+                for elem in name_elements:
+                    text = elem.get_text(strip=True)
+                    if len(text) > 3 and '$' not in text:
+                        product_name = self.clean_product_name(text)
+                        if product_name:
+                            break
+                if not product_name:
+                    continue
+                price = self.clean_price(price_element)
+                if product_name and price and price > 0:
+                    products.append({'name': product_name, 'price': price, 'search_term': search_term})
+            except Exception:
+                continue
+        return products
+
+    def scrape_with_requests(self, store_name: str, store_config: dict, search_term: str):
+        products = []
+        try:
+            search_url = store_config['url'] + store_config['search_pattern'].format(quote(search_term))
+            logger.info(f"Requesting: {search_url}")
+            self.session.headers['User-Agent'] = random.choice(self.user_agents)
+            response = self.session.get(search_url, timeout=10)
+            if response.status_code == 200:
+                products = self.extract_products_from_html(response.content, search_term)
+                logger.info(f"Found {len(products)} products via requests")
+            else:
+                logger.warning(f"Request failed with status code: {response.status_code}")
+        except Exception as exc:
+            logger.error(f"Error with requests: {exc}")
+        return products
+
+    def scrape_with_selenium(self, store_name: str, store_config: dict, search_term: str):
+        products = []
+        driver = None
+        try:
+            driver = webdriver.Chrome(options=self.chrome_options)
+            search_url = store_config['url'] + store_config['search_pattern'].format(quote(search_term))
+            logger.info(f"Selenium visiting: {search_url}")
+            driver.get(search_url)
+            WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.TAG_NAME, 'body')))
+            driver.execute_script("window.scrollTo(0, document.body.scrollHeight/2);")
+            time.sleep(1)
+            elements_with_prices = driver.find_elements(By.XPATH, "//*[contains(text(), '$')]")
+            for element in elements_with_prices[:30]:
+                try:
+                    parent = element
+                    for _ in range(3):
+                        if parent:
+                            parent = parent.find_element(By.XPATH, '..')
+                    if not parent:
+                        continue
+                    name_elements = parent.find_elements(By.CSS_SELECTOR, 'h1, h2, h3, h4, a, .title, .name, span')
+                    product_name = None
+                    for name_elem in name_elements:
+                        text = name_elem.text.strip()
+                        if len(text) > 3 and '$' not in text:
+                            product_name = self.clean_product_name(text)
+                            if product_name:
+                                break
+                    if not product_name:
+                        continue
+                    price = self.clean_price(element.text)
+                    if product_name and price and price > 0:
+                        products.append({'name': product_name, 'price': price, 'search_term': search_term})
+                except Exception:
+                    continue
+            logger.info(f"Found {len(products)} products via Selenium")
+        except Exception as exc:
+            logger.error(f"Error with Selenium: {exc}")
+        finally:
+            if driver:
+                driver.quit()
+        return products
+
+    def scrape_store(self, store_name: str, store_config: dict, category: str, search_terms):
+        all_products = []
+        for search_term in search_terms:
+            logger.info(f"Searching for '{search_term}' in {store_name}")
+            products = self.scrape_with_requests(store_name, store_config, search_term)
+            if not products:
+                products = self.scrape_with_selenium(store_name, store_config, search_term)
+            if products:
+                logger.info(f"Found {len(products)} products for '{search_term}'")
+                all_products.extend(products)
+            else:
+                logger.info(f"No products found for '{search_term}'")
+            time.sleep(random.uniform(1, 2))
+        unique = []
+        seen = set()
+        for product in all_products:
+            key = (product['name'].lower()[:20], round(product['price'], 0))
+            if key not in seen:
+                seen.add(key)
+                unique.append(product)
+        return unique
+
+    def scrape_all_stores(self):
+        logger.info("Starting product scraping...")
+        total_products = 0
+        for category, category_info in self.product_categories.items():
+            logger.info(f"Category: {category}")
+            search_terms = category_info['search_terms']
+            for store_name, store_config in self.stores.items():
+                logger.info(f"Checking {store_name}...")
+                try:
+                    logger.info(f"Searching for '{search_terms[0]}' in {store_name}")
+                    products = self.scrape_store(store_name, store_config, category, search_terms)
+                    if products:
+                        for product in products:
+                            self.results_by_category[category].append({
+                                'category': category,
+                                'store': store_name,
+                                'product_name': product['name'],
+                                'price': product['price'],
+                                'search_term': product['search_term'],
+                                'store_url': store_config['url']
+                            })
+                        logger.info(f"Added {len(products)} products from {store_name}")
+                        total_products += len(products)
+                    else:
+                        logger.info(f"No products found from {store_name}")
+                    time.sleep(random.uniform(1.5, 3.0))
+                except requests.exceptions.RequestException as exc:
+                    logger.error(f"Network error with {store_name}: {exc}")
+                    continue
+                except Exception as exc:
+                    logger.error(f"Error scraping {store_name} for {category}: {exc}")
+                    continue
+        logger.info(f"Completed scraping all stores. Found {total_products} total products.")
+
+    def save_category_csvs(self):
+        total_products = 0
+        saved_files = []
+        for category, products in self.results_by_category.items():
+            csv_filename = os.path.join(self.csv_dir, self.product_categories[category]['csv_filename'])
+            if not products:
+                logger.warning(f"No results for {category}")
+                pd.DataFrame(columns=['category', 'store', 'product_name', 'price', 'search_term', 'store_url']).to_csv(csv_filename, index=False)
+                print(f"Created empty file: {csv_filename}")
+                saved_files.append(csv_filename)
+                continue
+            df = pd.DataFrame(products)
+            df.to_csv(csv_filename, index=False)
+            total_products += len(df)
+            saved_files.append(csv_filename)
+            logger.info(f"Saved {len(df)} products to {csv_filename}")
+        print("\n" + "="*60)
+        print("\U0001F4CA CATEGORY-SPECIFIC CSV FILES GENERATED")
+        print("="*60)
+        print(f"Total products found: {total_products}")
+        print("\nCategory files created:")
+        for filepath in saved_files:
+            filename = os.path.basename(filepath)
+            category = os.path.splitext(filename)[0].replace('_', ' ').title()
+            product_count = len(pd.read_csv(filepath)) if os.path.exists(filepath) else 0
+            print(f"  • {category}: {product_count} products - {filename}")
+        print(f"\nAll files saved to: {self.csv_dir}/ directory")
+
+
+def main():
+    try:
+        scraper = ProductScraper()
+        print("Starting Category-Specific Product Scraper")
+        print(f"Searching {len(scraper.product_categories)} product categories across {len(scraper.stores)} stores")
+        print("Creating separate CSV files for each product type:")
+        for category, info in scraper.product_categories.items():
+            print(f"  • {category}: {info['csv_filename']}")
+        print()
+        scraper.scrape_all_stores()
+        scraper.save_category_csvs()
+    except Exception as exc:
+        logger.error(f"Error in main execution: {exc}")
+    logger.info("Scraping completed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- tune price optimization with category elasticity and markup limits
- round prices to psychological endings and record competitor counts
- expand `suggest_price` prompt with extra info and fallback optimization

## Testing
- `python3 -m py_compile price_optimizer.py scraper.py`
- `python3 price_optimizer.py`

------