### PR TITLE
Add dynamic keyword management

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ Install dependencies with:
 pip install pandas plotly requests
 ```
 
+### Adding products
+Use `manage_products.py` to register a new item and its keywords. This will
+create an empty CSV file for scraped data and update `category_keywords.json`.
+
+```bash
+python3 manage_products.py "Awesome Mug" AM0001 "Coffee mugs" --keywords "mug,cup"
+```
+
 ## Usage
 1. Ensure the mapping file `product_data_mapping.csv` and overview file `Dzukou_Pricing_Overview_With_Names - Copy.csv` are present in the repository.
 2. Run the optimizer to generate `recommended_prices.csv`:

--- a/category_keywords.json
+++ b/category_keywords.json
@@ -1,0 +1,34 @@
+{
+  "Sunglasses": [
+    "sunglasses"
+  ],
+  "Bottles": [
+    "bottle"
+  ],
+  "Coffee mugs": [
+    "mug"
+  ],
+  "Phone accessories": [
+    "phone"
+  ],
+  "Notebook": [
+    "notebook"
+  ],
+  "Lunchbox": [
+    "lunchbox"
+  ],
+  "Premium shawls": [
+    "premium shawl"
+  ],
+  "Eri silk shawls": [
+    "eri silk"
+  ],
+  "Cotton scarf": [
+    "cotton scarf"
+  ],
+  "Other scarves and shawls": [
+    "stole",
+    "shawl",
+    "scarf"
+  ]
+}

--- a/manage_products.py
+++ b/manage_products.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Utility for adding products and keywords used by the pricing pipeline."""
+import argparse
+import csv
+import json
+import re
+from pathlib import Path
+
+MAPPING_CSV = "product_data_mapping.csv"
+KEYWORDS_JSON = "category_keywords.json"
+DATA_DIR = Path("product_data")
+
+
+def sanitize_filename(name: str) -> str:
+    base = re.sub(r"\W+", "_", name.lower()).strip("_")
+    return base + ".csv"
+
+
+def load_keywords() -> dict:
+    if Path(KEYWORDS_JSON).exists():
+        with open(KEYWORDS_JSON, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
+def save_keywords(data: dict) -> None:
+    with open(KEYWORDS_JSON, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def add_product(name: str, prod_id: str, category: str, keywords: list[str]):
+    # ensure data directory
+    DATA_DIR.mkdir(exist_ok=True)
+    mapping = []
+    if Path(MAPPING_CSV).exists():
+        with open(MAPPING_CSV, newline="") as f:
+            mapping = list(csv.DictReader(f))
+
+    file_name = sanitize_filename(name)
+    data_file = DATA_DIR / file_name
+    if not data_file.exists():
+        data_file.write_text("category,store,product_name,price,search_term,store_url\n")
+
+    mapping.append({"Product Name": name, "Product ID": prod_id, "Data File": str(data_file)})
+    with open(MAPPING_CSV, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["Product Name", "Product ID", "Data File"])
+        writer.writeheader()
+        writer.writerows(mapping)
+
+    kw_data = load_keywords()
+    kws = kw_data.setdefault(category, [])
+    for kw in keywords:
+        if kw and kw not in kws:
+            kws.append(kw)
+    save_keywords(kw_data)
+    print(f"Added product '{name}' with data file {data_file}")
+
+
+def main():
+    p = argparse.ArgumentParser(description="Manage product data and keywords")
+    p.add_argument("name", help="Product name")
+    p.add_argument("product_id", help="Product ID")
+    p.add_argument("category", help="Product category")
+    p.add_argument("--keywords", help="Comma separated keywords for the category", default="")
+    args = p.parse_args()
+    keywords = [k.strip() for k in args.keywords.split(",") if k.strip()]
+    add_product(args.name, args.product_id, args.category, keywords)
+
+
+if __name__ == "__main__":
+    main()

--- a/price_optimizer.py
+++ b/price_optimizer.py
@@ -5,6 +5,7 @@ import csv
 import os
 import re
 import statistics
+import json
 from pathlib import Path
 from typing import Dict, List
 
@@ -219,7 +220,11 @@ def round_price(price: float) -> float:
     """Round price to a corporate-friendly format (e.g., 0.99)."""
     return round(price * 2) / 2 - 0.01
 
-CATEGORY_KEYWORDS = {
+# Default keywords used if no external mapping file is present. The
+# mapping associates categories with words that identify products in that
+# category. ``manage_products.py`` can update ``category_keywords.json`` to
+# customize this mapping.
+DEFAULT_CATEGORY_KEYWORDS = {
     "Sunglasses": ["sunglasses"],
     "Bottles": ["bottle"],
     "Coffee mugs": ["mug"],
@@ -231,6 +236,25 @@ CATEGORY_KEYWORDS = {
     "Cotton scarf": ["cotton scarf"],
     "Other scarves and shawls": ["stole", "shawl", "scarf"],
 }
+
+KEYWORDS_JSON = "category_keywords.json"
+
+
+def load_category_keywords() -> Dict[str, List[str]]:
+    """Return category keywords loaded from ``KEYWORDS_JSON`` if present."""
+    path = Path(KEYWORDS_JSON)
+    if path.exists():
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            if isinstance(data, dict):
+                return {k: list(map(str, v)) for k, v in data.items()}
+        except Exception:
+            pass
+    return DEFAULT_CATEGORY_KEYWORDS
+
+
+CATEGORY_KEYWORDS = load_category_keywords()
 
 
 def categorize_product(name: str) -> str:


### PR DESCRIPTION
## Summary
- support external category keywords via `category_keywords.json`
- provide `manage_products.py` helper to add items and keywords
- document how to add products in README

## Testing
- `python3 -m py_compile price_optimizer.py manage_products.py dashboard.py`
- `python3 price_optimizer.py`
- `python3 dashboard.py` *(after installing pandas, plotly, requests)*

------
https://chatgpt.com/codex/tasks/task_e_684ab5a85888832096004dcd20f71e8d