### PR TITLE
Handle empty categories in scraper

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -336,6 +336,11 @@ class ProductScraper:
         logger.info("Starting product scraping...")
         for category, info in self.product_categories.items():
             terms = info["search_terms"]
+            if not terms:
+                logger.warning(
+                    "No search terms for category '%s', skipping", category
+                )
+                continue
             for store_name, store_cfg in self.stores.items():
                 logger.info("Checking %s...", store_name)
                 try:


### PR DESCRIPTION
## Summary
- log a warning and skip categories that do not have search terms in `scrape_all_stores`

## Testing
- `python3 -m py_compile scraper.py`
- `python3 -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_684c853183588320b49aa5328bf72e7a