### PR TITLE
Add keyword requirement for products

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Run `manage_products.py` to open a small GUI for adding items and category
 keywords. The tool now lets you enter the product's current price and unit
 cost. It creates an empty CSV file for scraped data, updates
 `category_keywords.json`, and appends the pricing info to the overview CSV.
+At least one keyword must be provided when adding a product; otherwise the
+tool will show an error.
 
 ```bash
 python3 manage_products.py

--- a/manage_products.py
+++ b/manage_products.py
@@ -109,6 +109,9 @@ class ProductManagerGUI:
         if not category:
             messagebox.showerror("Error", "Category is required")
             return
+        if not keywords_str:
+            messagebox.showerror("Error", "At least one keyword is required")
+            return
         if not price_str or not cost_str:
             messagebox.showerror("Error", "Price and unit cost are required")
             return


### PR DESCRIPTION
## Summary
- validate that at least one keyword is provided when adding a product
- document the new requirement in the README

## Testing
- `python3 -m py_compile manage_products.py`

------
https://chatgpt.com/codex/tasks/task_e_684c852c92a08320a47d9e41d4be74fe