### PR TITLE
Use BASE_DIR paths in scripts

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -4,9 +4,10 @@ import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 from pathlib import Path
 
-OVERVIEW_CSV = "Dzukou_Pricing_Overview_With_Names - Copy.csv"
-RECOMMENDED_CSV = "recommended_prices.csv"
-OUT_HTML = "dashboard.html"
+BASE_DIR = Path(__file__).resolve().parent
+OVERVIEW_CSV = BASE_DIR / "Dzukou_Pricing_Overview_With_Names - Copy.csv"
+RECOMMENDED_CSV = BASE_DIR / "recommended_prices.csv"
+OUT_HTML = BASE_DIR / "dashboard.html"
 
 
 def load_data():
@@ -192,7 +193,7 @@ def build_dashboard(df, out_path=OUT_HTML):
 </html>
 """
     Path(out_path).write_text(html, encoding="utf-8")
-    print(f"Dashboard saved to {out_path}")
+    print(f"Dashboard saved to {str(out_path)}")
 
 
 def main():

--- a/manage_products.py
+++ b/manage_products.py
@@ -9,10 +9,11 @@ from pathlib import Path
 
 from scraper import DEFAULT_CATEGORIES
 
-MAPPING_CSV = "product_data_mapping.csv"
-KEYWORDS_JSON = "category_keywords.json"
-OVERVIEW_CSV = "Dzukou_Pricing_Overview_With_Names - Copy.csv"
-DATA_DIR = Path("product_data")
+BASE_DIR = Path(__file__).resolve().parent
+MAPPING_CSV = BASE_DIR / "product_data_mapping.csv"
+KEYWORDS_JSON = BASE_DIR / "category_keywords.json"
+OVERVIEW_CSV = BASE_DIR / "Dzukou_Pricing_Overview_With_Names - Copy.csv"
+DATA_DIR = BASE_DIR / "product_data"
 
 
 class ProductManagerGUI:
@@ -96,7 +97,7 @@ class ProductManagerGUI:
         return base + ".csv"
 
     def load_keywords(self) -> dict:
-        if Path(KEYWORDS_JSON).exists():
+        if KEYWORDS_JSON.exists():
             with open(KEYWORDS_JSON, "r", encoding="utf-8") as f:
                 return json.load(f)
         return {}
@@ -143,7 +144,7 @@ class ProductManagerGUI:
             DATA_DIR.mkdir(exist_ok=True)
 
             mapping = []
-            if Path(MAPPING_CSV).exists():
+            if MAPPING_CSV.exists():
                 with open(MAPPING_CSV, newline="") as f:
                     mapping = list(csv.DictReader(f))
 
@@ -163,7 +164,7 @@ class ProductManagerGUI:
 
             # update overview csv
             overview_rows = []
-            if Path(OVERVIEW_CSV).exists():
+            if OVERVIEW_CSV.exists():
                 with open(OVERVIEW_CSV, newline="", encoding="cp1252") as f:
                     overview_rows = list(csv.DictReader(f))
 
@@ -189,7 +190,7 @@ class ProductManagerGUI:
                     kws.append(kw)
             self.save_keywords(kw_data)
 
-            output_msg = f"Added product '{name}' with data file {data_file}\n"
+            output_msg = f"Added product '{name}' with data file {str(data_file)}\n"
             if category != category_input:
                 output_msg += f"Category mapped to existing '{category}'.\n"
             if keywords:
@@ -216,12 +217,12 @@ class ProductManagerGUI:
     def update_status(self):
         try:
             product_count = 0
-            if Path(MAPPING_CSV).exists():
+            if MAPPING_CSV.exists():
                 with open(MAPPING_CSV, newline="") as f:
                     product_count = len(list(csv.DictReader(f)))
 
             category_count = 0
-            if Path(KEYWORDS_JSON).exists():
+            if KEYWORDS_JSON.exists():
                 kw_data = self.load_keywords()
                 category_count = len(kw_data)
 

--- a/price_optimizer.py
+++ b/price_optimizer.py
@@ -9,6 +9,8 @@ import json
 from pathlib import Path
 from typing import Dict, List
 
+BASE_DIR = Path(__file__).resolve().parent
+
 PRICE_STEP = 0.25  # granularity for optimizer
 
 # Cap ratio relative to the mean competitor price. This is calculated
@@ -106,8 +108,8 @@ except ImportError:  # requests might not be installed; LLM calls become optiona
     requests = None
 
 
-OVERVIEW_CSV = "Dzukou_Pricing_Overview_With_Names - Copy.csv"
-MAPPING_CSV = "product_data_mapping.csv"
+OVERVIEW_CSV = BASE_DIR / "Dzukou_Pricing_Overview_With_Names - Copy.csv"
+MAPPING_CSV = BASE_DIR / "product_data_mapping.csv"
 
 # Minimum profit margins by category
 PROFIT_MARGINS = {
@@ -237,12 +239,12 @@ DEFAULT_CATEGORY_KEYWORDS = {
     "Other scarves and shawls": ["stole", "shawl", "scarf"],
 }
 
-KEYWORDS_JSON = "category_keywords.json"
+KEYWORDS_JSON = BASE_DIR / "category_keywords.json"
 
 
 def load_category_keywords() -> Dict[str, List[str]]:
     """Return category keywords loaded from ``KEYWORDS_JSON`` if present."""
-    path = Path(KEYWORDS_JSON)
+    path = KEYWORDS_JSON
     if path.exists():
         try:
             with open(path, "r", encoding="utf-8") as f:
@@ -536,7 +538,7 @@ def main():
                 "Profit Recommended": f"{profit_new:.2f}",
                 "Profit Delta": f"{(profit_new - profit_cur):.2f}",
             })
-    out_path = Path("recommended_prices.csv")
+    out_path = BASE_DIR / "recommended_prices.csv"
     with open(out_path, "w", newline="") as f:
         writer = csv.DictWriter(
             f,
@@ -558,7 +560,7 @@ def main():
         )
         writer.writeheader()
         writer.writerows(results)
-    print(f"Saved {len(results)} recommendations to {out_path}")
+    print(f"Saved {len(results)} recommendations to {str(out_path)}")
     print(
         f"Total estimated profit now: {total_current:.2f} -> {total_recommended:.2f} (delta {(total_recommended-total_current):.2f})"
     )

--- a/scraper.py
+++ b/scraper.py
@@ -19,9 +19,10 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
-MAPPING_CSV = "product_data_mapping.csv"
-KEYWORDS_JSON = "category_keywords.json"
-DATA_DIR = Path("product_data")
+BASE_DIR = Path(__file__).resolve().parent
+MAPPING_CSV = BASE_DIR / "product_data_mapping.csv"
+KEYWORDS_JSON = BASE_DIR / "category_keywords.json"
+DATA_DIR = BASE_DIR / "product_data"
 
 logging.basicConfig(
     level=logging.INFO,
@@ -187,12 +188,12 @@ class ProductScraper:
         self.product_categories = self.load_categories()
 
         self.csv_dir = DATA_DIR
-        os.makedirs(self.csv_dir, exist_ok=True)
+        self.csv_dir.mkdir(exist_ok=True)
         self.results_by_category = {cat: [] for cat in self.product_categories}
 
     def load_categories(self):
         data = DEFAULT_CATEGORIES.copy()
-        if Path(KEYWORDS_JSON).exists():
+        if KEYWORDS_JSON.exists():
             try:
                 with open(KEYWORDS_JSON, "r", encoding="utf-8") as f:
                     kw_data = json.load(f)
@@ -370,16 +371,16 @@ class ProductScraper:
             if products:
                 df = pd.DataFrame(products)
                 df.to_csv(path, index=False)
-                logger.info("Saved %d products to %s", len(df), path)
+                logger.info("Saved %d products to %s", len(df), str(path))
             else:
                 pd.DataFrame(columns=["category", "store", "product_name", "price", "search_term", "store_url"]).to_csv(path, index=False)
-                logger.info("Created empty file: %s", path)
+                logger.info("Created empty file: %s", str(path))
             saved.append(path)
         print("\nCategory files created:")
         for p in saved:
             count = len(pd.read_csv(p)) if p.exists() else 0
             print(f"  • {p.name}: {count} products")
-        print(f"\nAll files saved to: {self.csv_dir}/ directory")
+        print(f"\nAll files saved to: {str(self.csv_dir)}/ directory")
 
 
 def main():


### PR DESCRIPTION
## Summary
- add `BASE_DIR` constants in Python scripts
- construct path constants relative to each script
- print or log paths using `str()` when needed

## Testing
- `python3 -m py_compile manage_products.py scraper.py price_optimizer.py dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_684da758796c83209bda56dcd45048aa