### PR TITLE
Deduplicate categories in scraper

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -36,6 +36,11 @@ def sanitize_filename(text: str) -> str:
     return base + ".csv"
 
 
+def canonical_key(name: str) -> str:
+    """Return a lowercase key with only alphanumeric characters."""
+    return re.sub(r"[^a-z0-9]+", "", name.lower())
+
+
 DEFAULT_CATEGORIES = {
     "Wooden Sunglasses": {
         "search_terms": [
@@ -192,22 +197,43 @@ class ProductScraper:
         self.results_by_category = {cat: [] for cat in self.product_categories}
 
     def load_categories(self):
-        data = DEFAULT_CATEGORIES.copy()
+        """Return merged categories from defaults and keywords."""
+        merged = {}
+
+        # start with defaults using canonical keys
+        for cat, info in DEFAULT_CATEGORIES.items():
+            merged[canonical_key(cat)] = {
+                "name": cat,
+                "search_terms": list(info.get("search_terms", [])),
+                "csv_filename": info.get("csv_filename", sanitize_filename(cat)),
+            }
+
         if KEYWORDS_JSON.exists():
             try:
                 with open(KEYWORDS_JSON, "r", encoding="utf-8") as f:
                     kw_data = json.load(f)
                 for cat, kws in kw_data.items():
-                    info = data.get(cat, {})
-                    csv_name = info.get("csv_filename", sanitize_filename(cat))
-                    default_terms = info.get("search_terms", [])
-                    data[cat] = {
-                        "search_terms": list(set(default_terms + list(kws))),
-                        "csv_filename": csv_name,
-                    }
+                    key = canonical_key(cat)
+                    if key in merged:
+                        merged[key]["search_terms"] = list(
+                            set(merged[key]["search_terms"] + list(kws))
+                        )
+                    else:
+                        merged[key] = {
+                            "name": cat.strip(),
+                            "search_terms": list(kws),
+                            "csv_filename": sanitize_filename(cat),
+                        }
             except Exception as exc:
                 logger.warning("Failed loading keywords: %s", exc)
-        return data
+
+        return {
+            info["name"]: {
+                "search_terms": info["search_terms"],
+                "csv_filename": info["csv_filename"],
+            }
+            for info in merged.values()
+        }
 
     def clean_price(self, price_text):
         if not price_text:


### PR DESCRIPTION
## Summary
- add `canonical_key` helper in `scraper.py`
- merge duplicate categories in `load_categories`

## Testing
- `python -m py_compile scraper.py manage_products.py price_optimizer.py dashboard.py`
- `python - <<'PY'
import scraper
s=scraper.ProductScraper()
print(len(s.product_categories))
print('Lunch Box 1200ML' in s.product_categories)
PY`

------
https://chatgpt.com/codex/tasks/task_e_684da617e2448320b79e9fa4f833922a