### PR TITLE
Deduplicate categories via shared helper

### DIFF
--- a/manage_products.py
+++ b/manage_products.py
@@ -8,17 +8,13 @@ from tkinter import ttk, messagebox, scrolledtext
 from pathlib import Path
 
 from scraper import DEFAULT_CATEGORIES
+from utils import canonical_key
 
 BASE_DIR = Path(__file__).resolve().parent
 MAPPING_CSV = BASE_DIR / "product_data_mapping.csv"
 KEYWORDS_JSON = BASE_DIR / "category_keywords.json"
 OVERVIEW_CSV = BASE_DIR / "Dzukou_Pricing_Overview_With_Names - Copy.csv"
 DATA_DIR = BASE_DIR / "product_data"
-
-
-def canonical_key(name: str) -> str:
-    """Return a lowercase key with only alphanumeric characters."""
-    return re.sub(r"[^a-z0-9]+", "", name.lower())
 
 
 class ProductManagerGUI:

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,8 @@
+"""Utility functions for the pricing tools."""
+import re
+from pathlib import Path
+
+
+def canonical_key(name: str) -> str:
+    """Return a lowercase alphanumeric key for a category or filename."""
+    return re.sub(r"[^a-z0-9]+", "", name.lower())


### PR DESCRIPTION
## Summary
- add `utils.canonical_key`
- refactor `manage_products.py` and `scraper.py` to use the shared helper

## Testing
- `python -m py_compile scraper.py manage_products.py price_optimizer.py dashboard.py utils.py`
- `python - <<'PY'
import scraper
s = scraper.ProductScraper()
print(len(s.product_categories))
print('Lunch Box 1200ML' in s.product_categories)
print(list(s.product_categories.keys())[:5])
PY`


------
https://chatgpt.com/codex/tasks/task_e_684da617e2448320b79e9fa4f833922a