### PR TITLE
Refactor canonical_key helper

### DIFF
--- a/manage_products.py
+++ b/manage_products.py
@@ -8,19 +8,13 @@ from tkinter import ttk, messagebox, scrolledtext
 from pathlib import Path
 
 from scraper import DEFAULT_CATEGORIES
+from utils import canonical_key
 
 BASE_DIR = Path(__file__).resolve().parent
 MAPPING_CSV = BASE_DIR / "product_data_mapping.csv"
 KEYWORDS_JSON = BASE_DIR / "category_keywords.json"
 OVERVIEW_CSV = BASE_DIR / "Dzukou_Pricing_Overview_With_Names - Copy.csv"
 DATA_DIR = BASE_DIR / "product_data"
-
-
-def canonical_key(name: str) -> str:
-    """Return a lowercase key with only alphanumeric characters."""
-    return re.sub(r"[^a-z0-9]+", "", name.lower())
-
-
 class ProductManagerGUI:
     def __init__(self, root):
         self.root = root

--- a/scraper.py
+++ b/scraper.py
@@ -18,6 +18,7 @@ from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
+from utils import canonical_key
 
 BASE_DIR = Path(__file__).resolve().parent
 MAPPING_CSV = BASE_DIR / "product_data_mapping.csv"
@@ -34,11 +35,6 @@ logger = logging.getLogger(__name__)
 def sanitize_filename(text: str) -> str:
     base = re.sub(r"\W+", "_", text.lower()).strip("_")
     return base + ".csv"
-
-
-def canonical_key(name: str) -> str:
-    """Return a lowercase key with only alphanumeric characters."""
-    return re.sub(r"[^a-z0-9]+", "", name.lower())
 
 
 DEFAULT_CATEGORIES = {

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,7 @@
+"""Utility functions for the pricing tools."""
+import re
+
+
+def canonical_key(name: str) -> str:
+    """Return a lowercase alphanumeric key for a category or filename."""
+    return re.sub(r"[^a-z0-9]+", "", name.lower())


### PR DESCRIPTION
## Summary
- add a new `utils` module with `canonical_key`
- import `canonical_key` in `scraper.py` and `manage_products.py`

## Testing
- `python -m py_compile manage_products.py scraper.py price_optimizer.py dashboard.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684f1ab5ccb48320b39120a02e56825a