### PR TITLE
Increase default profit margin

### DIFF
--- a/price_optimizer.py
+++ b/price_optimizer.py
@@ -584,7 +584,7 @@ def suggest_price(
     cur: float,
     unit: float,
 ) -> float:
-    margin = PROFIT_MARGINS.get(category, 0.15)
+    margin = PROFIT_MARGINS.get(category, 0.30)
     elasticity = DEMAND_ELASTICITY.get(category, 1.2)
     max_markup = MAX_MARKUP.get(category, 1.8)
     max_increase = MAX_INCREASE.get(category, MAX_INCREASE["default"])


### PR DESCRIPTION
## Summary
- bump default margin for new categories to 30%

## Testing
- `python -m py_compile price_optimizer.py manage_products.py dashboard.py scraper.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6851b01c2d2c8320b182eb52f2760cd8